### PR TITLE
348 Fix hood sim

### DIFF
--- a/src/main/java/frc/robot/subsystems/Hood.java
+++ b/src/main/java/frc/robot/subsystems/Hood.java
@@ -172,7 +172,7 @@ public class Hood extends SubsystemBase {
             );
 
             motorSim = motor.getSimState();
-            motorSim.Orientation = ChassisReference.Clockwise_Positive;
+            motorSim.Orientation = ChassisReference.CounterClockwise_Positive;
             encoderSim = encoder.getSimState();
 
             encoderSim.Orientation = ChassisReference.Clockwise_Positive;


### PR DESCRIPTION
Change hood motor direction to CounterClockwisePositive. Tested in sim.