### PR TITLE
Fix Startup and Add logs to photonVision

### DIFF
--- a/src/main/java/frc/robot/subsystems/PhotonVision.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVision.java
@@ -83,9 +83,7 @@ public class PhotonVision extends SubsystemBase implements AutoCloseable {
         } catch (SocketException e) {
             log("*** ERROR CREATING DATAGRAM SOCKET ***" + e);
         }
-
-        this.previousTimeCount = System.currentTimeMillis();
-
+        
         // Start a separate thread to receive packets
         receiveThread = new Thread(() -> {
             // Run while the thread is still valid
@@ -93,7 +91,7 @@ public class PhotonVision extends SubsystemBase implements AutoCloseable {
                 try {
                     // Create a new packet to fill with recieved data
                     byte[] receiveData = new byte[40];
-                    var receivePacket = new DatagramPacket(receiveData, receiveData.length, VISION_PORT);
+                    var receivePacket = new DatagramPacket(receiveData, receiveData.length);
                     
                     if (socket != null) {
                         socket.receive(receivePacket);
@@ -133,7 +131,7 @@ public class PhotonVision extends SubsystemBase implements AutoCloseable {
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
-                    log("Error sleeping: " + e.getMessage());
+                    Thread.currentThread().interrupt();
                 }
             }
         });


### PR DESCRIPTION
Change code to ping all the time, not only in disable. 
Add if mac mini is connected and ping time in shuffleboard and in logs.
Fix issue on startup where it only bound to a specific IP address.
Tested in sim replacing mac IP with router IP and switching airplane mode on and off.
