### PR TITLE
Create an ignore hood retract command

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -147,8 +147,8 @@ public class RobotContainer {
         new Trigger(driver::getBButton).toggleOnTrue(turret.manual());
 
         /* Copilot */
-        new Trigger(() -> drivetrain.isNearTrench()).whileTrue(hood.retract());
-        new Trigger(copilot::getXButton).whileTrue(hood.retract().withInterruptBehavior(InterruptionBehavior.kCancelIncoming));
+        new Trigger(() -> drivetrain.isNearTrench()).whileTrue(hood.retractCommand());
+        new Trigger(copilot::getXButton).whileTrue(hood.retractCommand().withInterruptBehavior(InterruptionBehavior.kCancelIncoming));
 
         new Trigger(copilot::getLeftBumperButton).whileTrue(indexer.indexCommand(-IndexerConstants.SPINDEXDER_POWER,
             -IndexerConstants.TRANSFER_POWER));

--- a/src/main/java/frc/robot/subsystems/Hood.java
+++ b/src/main/java/frc/robot/subsystems/Hood.java
@@ -232,6 +232,9 @@ public class Hood extends SubsystemBase {
                 zeroingTimer.stop();
             }
         }
+        if (isHoodRetracted && !ignoreHoodRetract && hoodZeroed) {
+            motor.setControl(request.withPosition(HoodConstants.MAX_ANGLE));
+        }
         updateLogging();
     }
 
@@ -305,7 +308,7 @@ public class Hood extends SubsystemBase {
     }
 
     private void applyControl() {
-        if (!isHoodRetracted && hoodZeroed) {
+        if ((!isHoodRetracted || ignoreHoodRetract) && hoodZeroed) {
             motor.setControl(request.withPosition(getTargetAngleWithBias()));
         }
     }
@@ -385,18 +388,11 @@ public class Hood extends SubsystemBase {
      * Retracts the hood to its maximum angle ignoring the bias.
      * @return the command for retracting the hood
      */
-    public Command retract() {
-        return run(() -> {
-            if (ignoreHoodRetract) {
-                isHoodRetracted = false;
-            } else if (hoodZeroed) {
-                motor.setControl(request.withPosition(HoodConstants.MAX_ANGLE));
-                isHoodRetracted = true;
-            }
-        }).finallyDo(() -> {
-            isHoodRetracted = false;
-        });
+    public Command retractCommand() {
+        // do not require hood because it should run while allowing the hood to do something else (smart shoot)
+        return new StartEndCommand(() -> isHoodRetracted = true, () -> isHoodRetracted = false);
     }
+
 
     /**
      * While this command is running, the hood will not be forced to retract, used for smart shoot in auton


### PR DESCRIPTION
Add a command to ignore automatic hood retract. Useful for shooting under trench in auton. Remove duplicate smart shoot command.