### PR TITLE
479 fix collector zero

### DIFF
--- a/src/main/java/frc/robot/subsystems/Collector.java
+++ b/src/main/java/frc/robot/subsystems/Collector.java
@@ -12,7 +12,6 @@ import com.ctre.phoenix6.sim.TalonFXSimState.MotorType;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.networktables.BooleanEntry;
-import edu.wpi.first.networktables.BooleanSubscriber;
 import edu.wpi.first.networktables.NetworkTableInstance;
 
 import static edu.wpi.first.units.Units.Amps;


### PR DESCRIPTION
Make pivot zero use network table entries instead of shuffleboard. Also make a pivot zero for stow and deploy. Tested in sim and it works. The network table entries are now under a separate tag called collector.