### PR TITLE
Alliance Shift Checker

### DIFF
--- a/src/main/java/frc/util/AllianceHelpers.java
+++ b/src/main/java/frc/util/AllianceHelpers.java
@@ -40,12 +40,10 @@ public class AllianceHelpers {
 
         boolean redInactiveFirst = false;
         switch (gameData.charAt(0)) {
-            case 'R' -> redInactiveFirst = true;
-            case 'B' -> redInactiveFirst = false;
-            default -> {
-                // If we have invalid game data, assume hub is active.
-                return true;
-            }
+            case 'R':
+                    redInactiveFirst = true;
+            case 'B':
+                    redInactiveFirst = false;
         }
 
         // Shift one is active for blue if red won auto, or red if blue won auto.


### PR DESCRIPTION
I created a function in the alliance helpers class that periodically checks whether the hub is active or inactive in the robot's current alliance zone, based on previous scoring during the autonomous mode. I also tested this section of code in simulation as if either the blue or red alliance won the autonomous mode.