### PR TITLE
Fix supply current limits that were set but never enabled

### DIFF
--- a/src/main/java/frc/robot/subsystems/Collector.java
+++ b/src/main/java/frc/robot/subsystems/Collector.java
@@ -155,10 +155,10 @@ public class Collector extends SubsystemBase {
         pivotConfig.Slot0.kS = CollectorConstants.PIVOT_KS;
         pivotConfig.Feedback.SensorToMechanismRatio = CollectorConstants.ENCODER_TO_MECHANISM_RATIO;
 
-        pivotConfig.CurrentLimits.StatorCurrentLimitEnable = CollectorConstants.PIVOT_SUPPLY_LIMIT_ENABLE;
+        pivotConfig.CurrentLimits.SupplyCurrentLimitEnable = CollectorConstants.PIVOT_SUPPLY_LIMIT_ENABLE;
         pivotConfig.CurrentLimits.SupplyCurrentLimit = CollectorConstants.PIVOT_SUPPLY_LIMIT.in(Amps);
 
-        collectorConfig.CurrentLimits.StatorCurrentLimitEnable = CollectorConstants.COLLECTOR_SUPPLY_LIMIT_ENABLE;
+        collectorConfig.CurrentLimits.SupplyCurrentLimitEnable = CollectorConstants.COLLECTOR_SUPPLY_LIMIT_ENABLE;
         collectorConfig.CurrentLimits.SupplyCurrentLimit = CollectorConstants.COLLECTOR_SUPPLY_LIMIT.in(Amps);
 
         pivotMotor.applyConfig(pivotConfig);

--- a/src/main/java/frc/robot/subsystems/Hood.java
+++ b/src/main/java/frc/robot/subsystems/Hood.java
@@ -170,7 +170,7 @@ public class Hood extends SubsystemBase {
         motorConfig.Feedback.SensorToMechanismRatio = HoodConstants.ENCODER_TO_MECHANISM_RATIO;
         motorConfig.Feedback.RotorToSensorRatio = HoodConstants.ROTOR_TO_ENCODER_RATIO;
 
-        motorConfig.CurrentLimits.StatorCurrentLimitEnable = HoodConstants.SUPPLY_LIMIT_ENABLE;
+        motorConfig.CurrentLimits.SupplyCurrentLimitEnable = HoodConstants.SUPPLY_LIMIT_ENABLE;
         motorConfig.CurrentLimits.SupplyCurrentLimit = HoodConstants.SUPPLY_LIMIT.in(Amps);
 
         motor.applyConfig(motorConfig);


### PR DESCRIPTION
## Summary

- **Fixed three copy-paste bugs** where `StatorCurrentLimitEnable` was used instead of `SupplyCurrentLimitEnable`, causing supply current limits to be silently ignored by the motor controller
- **Affected motors**: Collector pivot (6A), Collector rollers (40A), and Hood (4A) - all had supply limits configured but never enforced because `SupplyCurrentLimitEnable` defaults to `false` in Phoenix 6
- **Heads up**: Once deployed, the Oasis pivot motor will be supply-limited to 6A for the first time. If it feels weaker, consider raising the limit (Mirage uses 20A for comparison)

Closes #525

## Test plan

- [ ] Deploy to robot and verify collector pivot, collector rollers, and hood motors still function normally
- [ ] Check Phoenix Tuner / Shuffleboard to confirm supply current limits are now active on all three motors
- [ ] Pay special attention to the collector pivot on Oasis - if 6A supply feels too restrictive, adjust `PIVOT_SUPPLY_LIMIT` in CollectorConstants
- [ ] Verify Turret and Indexer behavior is unchanged (their configs were already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)