### PR TITLE
Pivot motor: add gravity compensation and auto-zero on enable

### DIFF
--- a/src/main/java/frc/robot/subsystems/Collector.java
+++ b/src/main/java/frc/robot/subsystems/Collector.java
@@ -69,7 +69,10 @@ public class Collector extends SubsystemBase {
         public static final double PIVOT_KI = 0d; // temp
         public static final double PIVOT_KD = 0d; // temp
         public static final double PIVOT_KS = 0; // temp
-        public static final double PIVOT_KG = 0d; // temp
+        // Gravity compensation voltage. Negative = upward force (same convention
+        // as Hood kG). START LOW and increase until the arm holds position without
+        // sagging. If the arm drifts up, make the value less negative (closer to 0).
+        public static final double PIVOT_KG = RobotMap.IS_OASIS ? -0.15d : -0.15d; // tune me!
 
 
         // pivot
@@ -118,12 +121,12 @@ public class Collector extends SubsystemBase {
     private MechanismLigament2d ligament;
     private Angle targetPivotPosition;
     private PositionVoltage positionPID;
-    private boolean pivotZeroed = true;
+    private boolean pivotZeroed = false; // false = will auto-zero on first enable
     private final Timer zeroingTimer = new Timer();
     private boolean pivotActive = false;
     private BooleanEntry requestZeroingDeploy;
     private BooleanEntry requestZeroingStow;
-    private boolean stowZero = false;
+    private boolean stowZero = true; // true = zero toward stow (retracted) hard stop on startup
 
     private DCMotor gearbox;
 
@@ -153,6 +156,7 @@ public class Collector extends SubsystemBase {
         pivotConfig.Slot0.kI = CollectorConstants.PIVOT_KI;
         pivotConfig.Slot0.kD = CollectorConstants.PIVOT_KD;
         pivotConfig.Slot0.kS = CollectorConstants.PIVOT_KS;
+        pivotConfig.Slot0.kG = CollectorConstants.PIVOT_KG;
         pivotConfig.Feedback.SensorToMechanismRatio = CollectorConstants.ENCODER_TO_MECHANISM_RATIO;
 
         pivotConfig.CurrentLimits.StatorCurrentLimitEnable = CollectorConstants.PIVOT_SUPPLY_LIMIT_ENABLE;


### PR DESCRIPTION
## Summary
- **Add gravity compensation (kG = -0.15)** to the collector pivot motor config. Previously kG was defined as 0 and never actually applied to the motor, so only the P-term fought gravity -- causing arm sag, excess current draw, and stalling near the target position.
- **Auto-zero the pivot on first enable** by initializing `pivotZeroed = false` (was `true`) and `stowZero = true` (was `false`). The motor encoder reads 0 at power-on regardless of physical arm position, so skipping zeroing caused unpredictable behavior.

## Test plan
- [ ] Enable the robot and confirm the pivot runs its zeroing routine toward the stow hard stop on first enable
- [ ] Deploy the collector pivot and verify it holds position without visible sag
- [ ] Monitor pivot motor temperature over several minutes of use -- should run cooler than before
- [ ] Tune `PIVOT_KG` value if needed: more negative if arm sags, less negative if arm drifts up
- [ ] Verify that manually requesting zeroing via NetworkTables (deploy and stow) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #527