### PR TITLE
Fix canned shots firing with decelerating flywheel

### DIFF
--- a/src/main/java/frc/robot/subsystems/Cannon.java
+++ b/src/main/java/frc/robot/subsystems/Cannon.java
@@ -229,14 +229,17 @@ public class Cannon extends SubsystemBase {
     }
 
     /**
-     * Creates a cand shot command that uses only hood and shooter
+     * Creates a cand shot command that uses only hood and shooter.
+     * The shooter runs at target velocity for the entire duration (including
+     * while the indexer feeds balls), preventing the flywheel from decelerating
+     * during the shot.
      * @param value The cand shot value
      * @return The command
      */
     public Command createCandShotCommand(CannonConstants.CandShot value) {
         return new ParallelCommandGroup(
-            createCannonCommand(value.hoodAngle, value.shooterVelocity).andThen(hood.idle(), shooter.idle()),
-            
+            shooter.runShootCommand(() -> value.shooterVelocity()),
+            hood.setPositionCommand(value.hoodAngle()),
             indexWhenOnTarget()
         ).handleInterrupt(() -> {
             shooter.stop();
@@ -244,17 +247,20 @@ public class Cannon extends SubsystemBase {
             hood.stop();
             indexer.stop();
         });
-        
+
     }
 
     /**
-     * Creates a cand shot command that also uses turret
+     * Creates a cand shot command that also uses turret.
+     * The shooter runs at target velocity for the entire duration.
      * @param value The cand shot to use
      * @return The command
      */
     public Command createTurretCandShotCommand(CannonConstants.CandShot value) {
       return new ParallelCommandGroup(
-            createCannonCommand(value.turretAngle, value.hoodAngle, value.shooterVelocity).andThen(hood.idle(), shooter.idle()),
+            shooter.runShootCommand(() -> value.shooterVelocity()),
+            turret.setAngleCommand(value.turretAngle()),
+            hood.setPositionCommand(value.hoodAngle()),
             indexWhenOnTarget()
         );
     }


### PR DESCRIPTION
## Summary

- **Race condition fix**: `createCandShotCommand()` and `createTurretCandShotCommand()` used `shootCommand().until(isOnTarget)` which ended the instant the flywheel reached target speed, then transitioned to `idle()` which sent no motor commands. Balls fed into a decelerating flywheel.
- **Fix**: Replaced with `runShootCommand()` which calls `setVelocity()` every 20ms loop cycle for the entire duration of the command, actively maintaining target speed while balls feed through.
- OTF shooting was already correct and is not affected.

Closes #531

## Test plan

- [ ] Deploy to robot and run each canned shot preset
- [ ] Verify flywheel RPM stays at target (check Shuffleboard/NetworkTables) while balls are feeding
- [ ] Compare shot distance/consistency before and after — all balls in a burst should hit roughly the same spot
- [ ] Verify `handleInterrupt` still stops the shooter when the command is cancelled
- [ ] Confirm OTF shots still work correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)