### PR TITLE
Updated shooter/TOF/hood maps from field testing

### DIFF
--- a/src/main/java/frc/robot/subsystems/Cannon.java
+++ b/src/main/java/frc/robot/subsystems/Cannon.java
@@ -55,12 +55,12 @@ public class Cannon extends SubsystemBase {
             // put(Inches.of(64), Seconds.of(24.0/30.0));
             // put(Inches.of(142), Seconds.of(0.86));
             put(Inches.of(60), Seconds.of(0.88));
-            put(Inches.of(102), Seconds.of(1.0));
-            put(Inches.of(144), Seconds.of(1.166));
-            put(Inches.of(186), Seconds.of(1.51));
-            put(Inches.of(228), Seconds.of(1.4));
-            put(Inches.of(262), Seconds.of(1.46));
-            put(Inches.of(298), Seconds.of(1.66));
+            put(Inches.of(102), Seconds.of(0.91));
+            put(Inches.of(144), Seconds.of(1.04));
+            put(Inches.of(186), Seconds.of(1.17));
+            put(Inches.of(228), Seconds.of(1.39));
+            put(Inches.of(262), Seconds.of(1.2));
+            put(Inches.of(298), Seconds.of(1.4));
         }};
 
         public static final int MAX_OTF_ITERATIONS = 10;

--- a/src/main/java/frc/robot/subsystems/Hood.java
+++ b/src/main/java/frc/robot/subsystems/Hood.java
@@ -80,7 +80,7 @@ public class Hood extends SubsystemBase {
                 // put(Inches.of(183), Degrees.of(80));
                 // put(Feet.of(23), Degrees.of(66));
                 put(Inches.of(60), Degrees.of(80));
-                put(Inches.of(228), Degrees.of(77));
+                put(Inches.of(228), Degrees.of(64));
                 put(Inches.of(261), Degrees.of(65));
                 put(Inches.of(295), Degrees.of(65));
                 put(Inches.of(296), Degrees.of(56));

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -80,7 +80,7 @@ public class Shooter extends SubsystemBase {
                 // put(Inches.of(183), RotationsPerSecond.of(65));
                 // put(Feet.of(23), RotationsPerSecond.of(79));
                 put(Inches.of(60), RotationsPerSecond.of(41));
-                put(Inches.of(228), RotationsPerSecond.of(66));
+                put(Inches.of(228), RotationsPerSecond.of(62));
                 put(Inches.of(261), RotationsPerSecond.of(65));
                 put(Inches.of(295), RotationsPerSecond.of(71));
                 put(Inches.of(296), RotationsPerSecond.of(90));


### PR DESCRIPTION
## Summary
- Updated time-of-flight (TOF) map values at 102-298 inches based on filmed shot measurements from April practice sessions
- Reduced shooter velocity at 228 inches from 66 to 62 RPS (saves battery, less flywheel wear)
- Corrected hood angle at 228 inches from 77 to 64 degrees to match current robot configuration
- Note: the updated TOF data is intentionally non-monotonic (228" = 1.39s > 262" = 1.2s) because different distances use different arc profiles

## Test plan
- [ ] Verify the robot builds and deploys successfully
- [ ] Test shots at 228 inches and confirm improved accuracy with the new velocity (62 RPS) and hood angle (64 deg)
- [ ] Spot-check TOF-dependent behavior (on-the-fly aiming) at various distances
- [ ] Confirm no regressions at distances that were not changed (60 inches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #533