### PR TITLE
OTF shooting: fix interpolation, convergence, and loop performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,10 @@ deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
 
+test {
+    useJUnitPlatform()
+}
+
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'

--- a/src/main/java/frc/robot/subsystems/Cannon.java
+++ b/src/main/java/frc/robot/subsystems/Cannon.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
@@ -37,6 +38,7 @@ import frc.robot.subsystems.Indexer.IndexerConstants;
 import frc.robot.subsystems.Shooter.ShooterConstants;
 import frc.util.AllianceHelpers;
 import frc.util.shuffleboard.LightningShuffleboard;
+import frc.util.units.SplineMap;
 import frc.util.units.ThunderMap;
 
 public class Cannon extends SubsystemBase {
@@ -50,7 +52,10 @@ public class Cannon extends SubsystemBase {
 
         public record CandShot(Angle turretAngle, Angle hoodAngle, AngularVelocity shooterVelocity){};
 
-        public static final ThunderMap<Distance, Time> TIME_OF_FLIGHT_MAP = new ThunderMap<Distance, Time>() {{
+        // SplineMap uses cubic spline interpolation instead of linear.
+        // This correctly handles non-monotonic TOF data (e.g. high-arc shots
+        // at 228" take longer than flatter shots at 262").
+        public static final SplineMap<Distance, Time> TIME_OF_FLIGHT_MAP = new SplineMap<Distance, Time>() {{
             // put(Inches.of(18.78*12), Seconds.of(35.0/30.0));
             // put(Inches.of(64), Seconds.of(24.0/30.0));
             // put(Inches.of(142), Seconds.of(0.86));
@@ -63,8 +68,21 @@ public class Cannon extends SubsystemBase {
             put(Inches.of(298), Seconds.of(1.66));
         }};
 
-        public static final int MAX_OTF_ITERATIONS = 10;
+        public static final int MAX_OTF_ITERATIONS = 15;
         public static final Distance OTF_TOLERANCE = Inches.of(1.5);
+
+        // Under-relaxation factor for the OTF convergence loop.
+        // Each iteration blends the new prediction with the previous one:
+        //   pose_{n+1} = lerp(pose_n, prediction, RELAXATION)
+        //
+        // Without relaxation (factor = 1.0), convergence requires |v * dTOF/dd| < 1.
+        // With the spline TOF map, slopes can reach ~0.30 s/m, so at 4 m/s the
+        // raw contraction factor is 1.2 -- diverges!
+        //
+        // With relaxation, the effective contraction becomes RELAXATION * |v * dTOF/dd|.
+        // At 0.5: worst case is 0.5 * 5.0 * 0.35 = 0.875 -- converges at any FRC speed.
+        // Trade-off: lower = safer convergence but needs more iterations.
+        public static final double OTF_RELAXATION = 0.5;
       
         public static final CandShot LEFT_SHOT = new CandShot(Degrees.of(0), Degrees.of(63), RotationsPerSecond.of(55)); //Temp
         public static final CandShot RIGHT_SHOT = new CandShot(Degrees.of(0), Degrees.of(63), RotationsPerSecond.of(55)); //Temp
@@ -301,44 +319,109 @@ public class Cannon extends SubsystemBase {
     }
 
     /**
-     * YAY
+     * On-The-Fly shooting command.
+     *
+     * The convergence loop uses raw doubles (no Measure/Pose2d allocations)
+     * to avoid GC pressure on the roboRIO. Measure types are only created
+     * at the end when setting motor outputs.
+     *
      * @return DA OTFFF
      */
     public Command shootOTF() {
         return new RunCommand(() -> { // hi david (from Bea)
-            Time tof;
+            // ── Snapshot current state (one-time reads) ──────────────
 
-            Pose2d previousPose;
-            Pose2d futurePose = drivetrain.getPose();  
+            Pose2d pose = drivetrain.getPose();
+            ChassisSpeeds speeds = drivetrain.getCurrentRobotChassisSpeeds();
+            Translation2d target = getTargetTranslation();
 
-            Distance futureDist = getTargetDistance(); 
+            double robotX = pose.getX();
+            double robotY = pose.getY();
+            double sin = pose.getRotation().getSin();
+            double cos = pose.getRotation().getCos();
+
+            double targetX = target.getX();
+            double targetY = target.getY();
+
+            // Shooter offset in field frame (constant for this loop since dtheta=0)
+            double shooterOffX = CannonConstants.SHOOTER_TRANSLATION.getX();
+            double shooterOffY = CannonConstants.SHOOTER_TRANSLATION.getY();
+            double shooterFieldX = shooterOffX * cos - shooterOffY * sin;
+            double shooterFieldY = shooterOffX * sin + shooterOffY * cos;
+
+            // Robot-relative velocity of the shooter offset due to chassis rotation,
+            // then rotated to field frame and added to chassis velocity.
+            // This matches getFuturePoseFromTime's existing math.
+            double rrXVel = -speeds.omegaRadiansPerSecond * shooterOffY;
+            double rrYVel =  speeds.omegaRadiansPerSecond * shooterOffX;
+            double totalVx = speeds.vxMetersPerSecond + (rrXVel * cos - rrYVel * sin);
+            double totalVy = speeds.vyMetersPerSecond + (rrXVel * sin + rrYVel * cos);
+
+            double driveMultiplier = LightningShuffleboard.getDouble("Cannon", "OTF Multiplier", 1);
+
+            // ── Initial state: current shooter position ──────────────
+
+            double futureX = robotX;
+            double futureY = robotY;
+
+            double sx = robotX + shooterFieldX;
+            double sy = robotY + shooterFieldY;
+            double futureDist = Math.sqrt((targetX - sx) * (targetX - sx) + (targetY - sy) * (targetY - sy));
+
+            double toleranceSq = CannonConstants.OTF_TOLERANCE.in(Meters);
+            toleranceSq *= toleranceSq; // compare squared to avoid sqrt in convergence check
+
+            // ── Convergence loop (zero allocations) ──────────────────
 
             for (int i = 0; i < CannonConstants.MAX_OTF_ITERATIONS; i++) {
-                tof = CannonConstants.TIME_OF_FLIGHT_MAP.get(futureDist);
+                double tof = CannonConstants.TIME_OF_FLIGHT_MAP.getBaseUnit(futureDist);
+                double dt = tof * driveMultiplier;
 
-                previousPose = futurePose;
-                futurePose = drivetrain.getFuturePoseFromTime(tof);
+                // Predict future robot position: pose.exp(twist) with dtheta=0
+                // simplifies to rotating the twist by the heading then translating.
+                double twistDx = totalVx * dt;
+                double twistDy = totalVy * dt;
+                double rawX = robotX + twistDx * cos - twistDy * sin;
+                double rawY = robotY + twistDx * sin + twistDy * cos;
 
-                futureDist = getTargetDistance(futurePose);
+                // Under-relaxation: blend toward prediction to guarantee convergence
+                double prevX = futureX;
+                double prevY = futureY;
+                futureX = prevX + CannonConstants.OTF_RELAXATION * (rawX - prevX);
+                futureY = prevY + CannonConstants.OTF_RELAXATION * (rawY - prevY);
 
-                if (Math.abs(futurePose.minus(previousPose).getTranslation().getNorm()) < CannonConstants.OTF_TOLERANCE.in(Meters)) {
+                // Distance from future shooter position to target
+                sx = futureX + shooterFieldX;
+                sy = futureY + shooterFieldY;
+                futureDist = Math.sqrt((targetX - sx) * (targetX - sx) + (targetY - sy) * (targetY - sy));
+
+                // Convergence check (squared distance avoids sqrt)
+                double dx = futureX - prevX;
+                double dy = futureY - prevY;
+                if (dx * dx + dy * dy < toleranceSq) {
                     break;
                 }
             }
-           
-            Angle hoodAngle = Hood.HoodConstants.HOOD_MAP.get(futureDist);
-            AngularVelocity shooterVelocity = Shooter.ShooterConstants.VELOCITY_MAP.get(futureDist);
+
+            // ── Set motor outputs (allocations only happen here) ─────
+
+            Distance futureDistMeasure = Meters.of(futureDist);
+            Angle hoodAngle = Hood.HoodConstants.HOOD_MAP.get(futureDistMeasure);
+            AngularVelocity shooterVelocity = Shooter.ShooterConstants.VELOCITY_MAP.get(futureDistMeasure);
 
             hood.setPosition(hoodAngle);
             shooter.setVelocity(shooterVelocity);
 
+            Pose2d futurePose = new Pose2d(futureX, futureY, pose.getRotation());
+            LightningShuffleboard.setPose2d("Cannon", "Future Pose", futurePose);
+
             turret.turretAim(new Pose2d(getShooterTranslation(futurePose), futurePose.getRotation()), getTarget(), getRobotAngularVelocity(), getHubAngularVelocity());
       }, turret, shooter, hood)
       .alongWith(indexWhenOnTarget().onlyWhile(() -> turret.isOnTarget(Degrees.of(12))).repeatedly());
-    
+
     //   .alongWith(drivetrain.increaseRampRates())
     //   .alongWith(drivetrain.lowerSupplyLimits());
-      
+
     }
 
     /**

--- a/src/main/java/frc/util/units/SplineMap.java
+++ b/src/main/java/frc/util/units/SplineMap.java
@@ -1,0 +1,199 @@
+package frc.util.units;
+
+import java.util.Arrays;
+import java.util.TreeMap;
+
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.Unit;
+
+/**
+ * Drop-in replacement for {@link ThunderMap} that uses <b>natural cubic spline</b>
+ * interpolation instead of linear interpolation.
+ * <p>
+ * <b>When to use this instead of ThunderMap:</b> whenever the data is non-monotonic
+ * or changes slope rapidly between calibration points. Linear interpolation draws
+ * straight lines between points, which can produce large errors when the true curve
+ * bends. A cubic spline fits smooth curves through every data point, tracking the
+ * actual shape much more faithfully.
+ * <p>
+ * <b>How natural cubic splines work (the short version):</b>
+ * <ol>
+ *   <li>Between each pair of adjacent data points, we fit a cubic polynomial
+ *       (4 unknowns: a + b*x + c*x² + d*x³).</li>
+ *   <li>We require that neighboring polynomials agree on value, first derivative,
+ *       and second derivative at the shared data point. This gives us a smooth curve
+ *       with no kinks.</li>
+ *   <li>"Natural" means we set the second derivative to zero at the two endpoints,
+ *       which keeps the curve from doing anything wild at the edges.</li>
+ *   <li>The system of equations is tridiagonal, so we solve it in O(n) time —
+ *       essentially instant for our 7-point maps.</li>
+ * </ol>
+ * <p>
+ * Usage is identical to ThunderMap:
+ * <pre>{@code
+ * SplineMap<Distance, Time> tofMap = new SplineMap<>() {{
+ *     put(Inches.of(60),  Seconds.of(0.88));
+ *     put(Inches.of(102), Seconds.of(0.91));
+ *     // ...
+ * }};
+ * Time tof = tofMap.get(Inches.of(150));
+ * }</pre>
+ *
+ * @param <K> Key measure type (e.g. Distance)
+ * @param <V> Value measure type (e.g. Time, Angle, AngularVelocity)
+ */
+public class SplineMap<K extends Measure<?>, V extends Measure<?>> {
+
+    private Unit valueUnit;
+    private final TreeMap<Double, Double> rawData = new TreeMap<>();
+
+    // Spline coefficients for each segment [i, i+1).
+    // S_i(x) = a[i] + b[i]*(x-x[i]) + c[i]*(x-x[i])^2 + d[i]*(x-x[i])^3
+    private double[] xs;
+    private double[] a; // = y values
+    private double[] b;
+    private double[] c;
+    private double[] d;
+    private boolean built = false;
+
+    public SplineMap() {}
+
+    /**
+     * Adds a calibration data point. Units are handled automatically
+     * (same as ThunderMap).
+     */
+    @SuppressWarnings("unchecked")
+    public void put(K key, V value) {
+        valueUnit = value.baseUnit();
+        rawData.put(key.baseUnitMagnitude(), value.baseUnitMagnitude());
+        built = false;
+    }
+
+    /**
+     * Returns the spline-interpolated value at the given key.
+     * Outside the data range, the value is clamped to the nearest endpoint
+     * (no extrapolation).
+     */
+    @SuppressWarnings("unchecked")
+    public V get(K key) {
+        if (!built) {
+            buildSpline();
+        }
+        double x = key.baseUnitMagnitude();
+        return (V) valueUnit.of(evaluate(x));
+    }
+
+    /**
+     * Zero-allocation lookup: takes and returns raw doubles in
+     * <b>base SI units</b> (meters, seconds, radians, etc.).
+     * Use this in tight loops where GC pressure matters (e.g. the OTF
+     * convergence loop on the roboRIO).
+     *
+     * @param keyBaseUnit key in base units (e.g. meters for Distance)
+     * @return interpolated value in base units (e.g. seconds for Time)
+     */
+    public double getBaseUnit(double keyBaseUnit) {
+        if (!built) {
+            buildSpline();
+        }
+        return evaluate(keyBaseUnit);
+    }
+
+    // ── Spline construction (runs once, then cached) ──────────────────
+
+    private void buildSpline() {
+        int n = rawData.size();
+        if (n < 2) {
+            throw new IllegalStateException("SplineMap needs at least 2 data points");
+        }
+
+        xs = new double[n];
+        a  = new double[n];
+        int idx = 0;
+        for (var entry : rawData.entrySet()) {
+            xs[idx] = entry.getKey();
+            a[idx]  = entry.getValue();
+            idx++;
+        }
+
+        // With only 2 points, fall back to linear interpolation
+        if (n == 2) {
+            b = new double[]{ (a[1] - a[0]) / (xs[1] - xs[0]) };
+            c = new double[2];
+            d = new double[1];
+            built = true;
+            return;
+        }
+
+        // Step sizes between consecutive data points
+        double[] h = new double[n - 1];
+        for (int i = 0; i < n - 1; i++) {
+            h[i] = xs[i + 1] - xs[i];
+        }
+
+        // ── Solve tridiagonal system for c[] (second-derivative / 2) ──
+        //
+        // For interior points i = 1..n-2, the smoothness condition gives:
+        //   h[i-1]*c[i-1] + 2*(h[i-1]+h[i])*c[i] + h[i]*c[i+1]
+        //     = 3*( (a[i+1]-a[i])/h[i] - (a[i]-a[i-1])/h[i-1] )
+        //
+        // Natural boundary: c[0] = c[n-1] = 0.
+        //
+        // We solve this with the Thomas algorithm (forward sweep + back sub).
+
+        double[] alpha = new double[n];
+        for (int i = 1; i < n - 1; i++) {
+            alpha[i] = 3.0 / h[i] * (a[i + 1] - a[i])
+                      - 3.0 / h[i - 1] * (a[i] - a[i - 1]);
+        }
+
+        double[] l  = new double[n];
+        double[] mu = new double[n];
+        double[] z  = new double[n];
+
+        l[0]  = 1;
+        mu[0] = 0;
+        z[0]  = 0;
+
+        for (int i = 1; i < n - 1; i++) {
+            l[i]  = 2.0 * (xs[i + 1] - xs[i - 1]) - h[i - 1] * mu[i - 1];
+            mu[i] = h[i] / l[i];
+            z[i]  = (alpha[i] - h[i - 1] * z[i - 1]) / l[i];
+        }
+
+        c = new double[n];
+        b = new double[n - 1];
+        d = new double[n - 1];
+
+        // Natural boundary at right endpoint
+        c[n - 1] = 0;
+
+        // Back-substitution
+        for (int j = n - 2; j >= 0; j--) {
+            c[j] = z[j] - mu[j] * c[j + 1];
+            b[j] = (a[j + 1] - a[j]) / h[j]
+                   - h[j] * (c[j + 1] + 2.0 * c[j]) / 3.0;
+            d[j] = (c[j + 1] - c[j]) / (3.0 * h[j]);
+        }
+
+        built = true;
+    }
+
+    // ── Evaluation ────────────────────────────────────────────────────
+
+    private double evaluate(double x) {
+        // Clamp to data range (no extrapolation)
+        if (x <= xs[0])              return a[0];
+        if (x >= xs[xs.length - 1])  return a[xs.length - 1];
+
+        // Binary search for the segment containing x
+        int i = Arrays.binarySearch(xs, x);
+        if (i >= 0) return a[i]; // exact hit on a data point
+
+        // binarySearch returns -(insertionPoint) - 1 on miss
+        i = -i - 2;
+
+        double dx = x - xs[i];
+        return a[i] + dx * (b[i] + dx * (c[i] + dx * d[i]));
+    }
+}

--- a/src/test/java/frc/util/SplineMapTest.java
+++ b/src/test/java/frc/util/SplineMapTest.java
@@ -1,0 +1,93 @@
+package frc.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.Seconds;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.Time;
+import frc.util.units.SplineMap;
+import frc.util.units.ThunderMap;
+
+/**
+ * Tests for SplineMap and OTF convergence analysis.
+ *
+ * Run with: ./gradlew test --tests "frc.util.SplineMapTest"
+ * The print tests produce tables showing interpolation accuracy and convergence.
+ */
+class SplineMapTest {
+
+    // The actual TOF data from Cannon.java
+    static SplineMap<Distance, Time> splineMap = new SplineMap<>() {{
+        put(Inches.of(60),  Seconds.of(0.88));
+        put(Inches.of(102), Seconds.of(1.0));
+        put(Inches.of(144), Seconds.of(1.166));
+        put(Inches.of(186), Seconds.of(1.51));
+        put(Inches.of(228), Seconds.of(1.4));
+        put(Inches.of(262), Seconds.of(1.46));
+        put(Inches.of(298), Seconds.of(1.66));
+    }};
+
+    static ThunderMap<Distance, Time> linearMap = new ThunderMap<>() {{
+        put(Inches.of(60),  Seconds.of(0.88));
+        put(Inches.of(102), Seconds.of(1.0));
+        put(Inches.of(144), Seconds.of(1.166));
+        put(Inches.of(186), Seconds.of(1.51));
+        put(Inches.of(228), Seconds.of(1.4));
+        put(Inches.of(262), Seconds.of(1.46));
+        put(Inches.of(298), Seconds.of(1.66));
+    }};
+
+    @Test
+    void splineHitsExactDataPoints() {
+        // Spline must pass through every calibrated value exactly
+        assertEquals(0.88, splineMap.get(Inches.of(60)).in(Seconds),  1e-6);
+        assertEquals(1.0, splineMap.get(Inches.of(102)).in(Seconds), 1e-6);
+        assertEquals(1.166, splineMap.get(Inches.of(144)).in(Seconds), 1e-6);
+        assertEquals(1.51, splineMap.get(Inches.of(186)).in(Seconds), 1e-6);
+        assertEquals(1.4, splineMap.get(Inches.of(228)).in(Seconds), 1e-6);
+        assertEquals(1.46,  splineMap.get(Inches.of(262)).in(Seconds), 1e-6);
+        assertEquals(1.66, splineMap.get(Inches.of(298)).in(Seconds), 1e-6);
+    }
+
+    @Test
+    void splineClampsOutsideRange() {
+        // Below minimum should return the first value
+        assertEquals(0.88, splineMap.get(Inches.of(0)).in(Seconds), 1e-6);
+        // Above maximum should return the last value
+        assertEquals(1.66, splineMap.get(Inches.of(500)).in(Seconds), 1e-6);
+    }
+
+    @Test
+    void splinePreservesPeakBetterThanLinear() {
+        // At 207" (midway between 186 and 228):
+        // Linear interpolation draws a straight line from 1.51 -> 1.4,
+        // The spline should capture the peak shape better.
+        double linearVal = linearMap.get(Inches.of(207)).in(Seconds);
+        double splineVal = splineMap.get(Inches.of(207)).in(Seconds);
+
+        System.out.println("TOF at 207 inches:");
+        System.out.println("  Linear: " + linearVal + "s");
+        System.out.println("  Spline: " + splineVal + "s");
+
+        // Spline should be higher than linear because it follows the curve's
+        // upward momentum before bending down
+        assertTrue(splineVal > linearVal,
+            "Spline should stay higher than linear in the peak region");
+    }
+
+    @Test
+    void printInterpolationComparison() {
+        // Print a comparison table so students can visualize the difference
+        System.out.println("\nDistance(in) | Linear TOF(s) | Spline TOF(s) | Diff(s)");
+        System.out.println("------------|---------------|---------------|--------");
+        for (int d = 60; d <= 298; d += 10) {
+            double lin = linearMap.get(Inches.of(d)).in(Seconds);
+            double spl = splineMap.get(Inches.of(d)).in(Seconds);
+            System.out.printf("%11d | %13.4f | %13.4f | %+.4f%n", d, lin, spl, spl - lin);
+        }
+    }
+}


### PR DESCRIPTION
Closes #535

## Summary
- **SplineMap for non-monotonic TOF data** -- replaces `ThunderMap` (linear interpolation) with cubic spline interpolation for the time-of-flight lookup. Linear interpolation gives wrong values between the non-monotonic calibration points (228" high-arc shot takes longer than 262" flat shot). Spline fits smooth curves through all data points.
- **Under-relaxation fixes convergence** -- the OTF fixed-point iteration diverges when `|speed * dTOF/dDist| > 1`, which happens above ~3.3 m/s with the spline slopes. Added 0.5 relaxation factor so each iteration blends halfway toward the prediction, keeping the loop stable at any FRC speed.
- **Zero-allocation loop** -- rewrote the OTF convergence loop to use raw `double` arithmetic instead of `Pose2d`/`Measure` objects. Allocations only happen at the end when setting motor outputs. `SplineMap.getBaseUnit()` provides a no-allocation lookup path. Estimated: ~3500 objects/sec eliminated.
- **build.gradle test fix** -- added `useJUnitPlatform()` so `./gradlew test` actually discovers and runs JUnit 5 tests.

## Test plan
- [ ] Run `./gradlew test --tests "frc.util.SplineMapTest"` -- all 4 tests pass, check the printed interpolation table
- [ ] Deploy to robot, drive at various speeds while OTF shooting -- verify shots land closer than before
- [ ] At high speed (>3 m/s), verify OTF doesn't oscillate (watch "Future Pose" on Shuffleboard)
- [ ] Verify canned shots and static shooting still work (no regressions)

:robot: Generated with [Claude Code](https://claude.com/claude-code)