### PR TITLE
Add Timestamp to Robot Log Pose Entries

### DIFF
--- a/src/main/java/frc/robot/mac/MacMini.java
+++ b/src/main/java/frc/robot/mac/MacMini.java
@@ -278,7 +278,7 @@ public class MacMini implements AutoCloseable {
             if (poseOpt.isPresent()) {
                 // The pose
                 EstimatedRobotPose pose = poseOpt.get();
-                cameraInfo.logEntry().robotPoseEntry.append(pose.estimatedPose.toPose2d());
+                cameraInfo.logEntry().robotPoseEntry.append(pose.estimatedPose.toPose2d(), getMicroSeconds());
                 
                 // Add the vision measurment
                 return new VisionInfo(useableResult, pose);
@@ -289,7 +289,7 @@ public class MacMini implements AutoCloseable {
                 if (poseOpt.isPresent()) {
                     // The pose
                     EstimatedRobotPose pose = poseOpt.get();
-                    cameraInfo.logEntry().robotPoseEntry.append(pose.estimatedPose.toPose2d());
+                    cameraInfo.logEntry().robotPoseEntry.append(pose.estimatedPose.toPose2d(), getMicroSeconds());
 
                     // Add the vision measurment
                     return new VisionInfo(useableResult, pose);


### PR DESCRIPTION
I added the timestamp for the robot log pose entries to avoid the delay between robotPose and each tagPose during logging.