### PR TITLE
Fix OTF aiming at field walls with velocity clamping

### DIFF
--- a/src/main/java/frc/robot/constants/FieldConstants.java
+++ b/src/main/java/frc/robot/constants/FieldConstants.java
@@ -48,4 +48,7 @@ public class FieldConstants {
     public static final Rectangle2d RED_NO_PASSING_ZONE = new Rectangle2d(new Translation2d(16.541, 4.473), new Translation2d(12.677, 3.486)); // temp, values found with sim
 
     public static final double FIELD_MIDDLE_Y = 4.034663;
+
+    public static final double FIELD_LENGTH = 16.540988; // meters (X extent)
+    public static final double FIELD_WIDTH = 8.069326;   // meters (Y extent)
 }

--- a/src/main/java/frc/robot/subsystems/Cannon.java
+++ b/src/main/java/frc/robot/subsystems/Cannon.java
@@ -413,7 +413,7 @@ public class Cannon extends SubsystemBase {
 
         double robotTargetAngle = getTargetAngle(pose).in(Radians);
         
-        Translation2d fieldRelativeVelocity = new Translation2d(drivetrain.getCurrentRobotChassisSpeeds().vxMetersPerSecond, drivetrain.getCurrentRobotChassisSpeeds().vyMetersPerSecond).rotateBy(drivetrain.getPose().getRotation());
+        Translation2d fieldRelativeVelocity = new Translation2d(drivetrain.getWallCorrectedChassisSpeeds().vxMetersPerSecond, drivetrain.getWallCorrectedChassisSpeeds().vyMetersPerSecond).rotateBy(drivetrain.getPose().getRotation());
 
         double hubRotation = (-fieldRelativeVelocity.getX() * Math.sin(robotTargetAngle) + fieldRelativeVelocity.getY() * Math.cos(robotTargetAngle)) / getTargetDistance().in(Meters);
         return RadiansPerSecond.of(hubRotation);

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -430,8 +430,39 @@ public class Swerve extends TunerSwerveDrivetrain implements Subsystem {
         return getState().Speeds;
     }
 
-    public Pose2d getFuturePoseFromTime(Time time) {
+    // When the robot is pressed against a field wall, wheels spin but the robot
+    // doesn't actually move into the wall. This zeros the velocity component
+    // pointing off-field so the OTF solver doesn't lead shots based on phantom motion.
+    private static final double WALL_MARGIN = 0.20; // meters (~8 in, bumper width + tolerance)
+
+    public ChassisSpeeds getWallCorrectedChassisSpeeds() {
         ChassisSpeeds speeds = getCurrentRobotChassisSpeeds();
+        Pose2d pose = getPose();
+
+        double sin = pose.getRotation().getSin();
+        double cos = pose.getRotation().getCos();
+
+        // Robot-relative to field-relative
+        double fieldVx = speeds.vxMetersPerSecond * cos - speeds.vyMetersPerSecond * sin;
+        double fieldVy = speeds.vxMetersPerSecond * sin + speeds.vyMetersPerSecond * cos;
+
+        Translation2d pos = pose.getTranslation();
+
+        // Clamp velocity component pointing out of the field near each wall
+        if (pos.getX() < WALL_MARGIN && fieldVx < 0)                          fieldVx = 0;
+        if (pos.getX() > FieldConstants.FIELD_LENGTH - WALL_MARGIN && fieldVx > 0) fieldVx = 0;
+        if (pos.getY() < WALL_MARGIN && fieldVy < 0)                          fieldVy = 0;
+        if (pos.getY() > FieldConstants.FIELD_WIDTH - WALL_MARGIN && fieldVy > 0)  fieldVy = 0;
+
+        // Field-relative back to robot-relative
+        double rrVx =  fieldVx * cos + fieldVy * sin;
+        double rrVy = -fieldVx * sin + fieldVy * cos;
+
+        return new ChassisSpeeds(rrVx, rrVy, speeds.omegaRadiansPerSecond);
+    }
+
+    public Pose2d getFuturePoseFromTime(Time time) {
+        ChassisSpeeds speeds = getWallCorrectedChassisSpeeds();
         double dt = time.in(Seconds);
 
         double driveMultiplier = LightningShuffleboard.getDouble("Cannon", "OTF Multiplier", 1);


### PR DESCRIPTION
## Summary
- Adds `getWallCorrectedChassisSpeeds()` to `Swerve` that zeros the velocity component pointing off-field when the robot is within ~8 inches of a wall boundary
- `getFuturePoseFromTime()` and Cannon's hub angular velocity now use corrected speeds
- `getCurrentRobotChassisSpeeds()` is unchanged — PathPlanner and other consumers are unaffected

## Problem
When strafing against a field wall, wheel odometry reports velocity into the wall (wheels spin but robot doesn't move). The OTF solver uses this phantom velocity to predict future pose, causing it to lead shots incorrectly.

## Approach
Wall-aware clamping is preferred over pose differentiation because it:
- Adds zero noise (keeps 250Hz wheel odometry for normal driving)
- Has no latency (unlike vision-differentiated velocity)
- Only modifies the specific velocity component that's wrong
- Preserves parallel-to-wall velocity (which is correct and needed for OTF)

## Test plan
- [ ] Verify static aiming is unaffected (robot not near walls)
- [ ] Test OTF while strafing along a wall — shots should no longer over-lead
- [ ] Test OTF while strafing into a corner — both X and Y clamping active
- [ ] Verify turret feedforward is smooth near walls (no jitter)

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)